### PR TITLE
Go Profiler - Add more test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
         ```
         require (
-            go.stackify.com/apm vx.x.x
+            github.com/stackify/stackify-go-apm vx.x.x
             ...
         )
         ```
@@ -22,7 +22,7 @@
     - Install stackify go apm
 
         ```
-        $ go get go.stackify.com/apm
+        $ go get github.com/stackify/stackify-go-apm
         ```
 
 4. Update and insert the apm settings to your application.
@@ -34,7 +34,7 @@
         "context"
         "log"
 
-        "go.stackify.com/apm"
+        "github.com/stackify/stackify-go-apm"
     )
 
     func main() {

--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,10 @@ func (tt transportType) Apply(config *Config) {
 }
 
 func WithTransportType(tt string) ConfigOptions {
+	_, ok := TransportTypes[tt]
+	if !ok {
+		return transportType(DefaultTransportType)
+	}
 	return transportType(tt)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,54 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stackify/stackify-go-apm/config"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	c := config.NewConfig()
+
+	assert.Equal(t, c.ApplicationName, "Go Application")
+	assert.Equal(t, c.EnvironmentName, "Production")
+	assert.Equal(t, c.Debug, false)
+	assert.Equal(t, c.TransportType, "default")
+	assert.Equal(t, c.LogPath, "/usr/local/stackify/stackify-python-apm/log/")
+	assert.Equal(t, c.LogFileThresholdSize, int64(50000000))
+	assert.NotEmpty(t, c.BaseDIR)
+	assert.NotEmpty(t, c.HostName)
+	assert.NotEmpty(t, c.OSType)
+	assert.NotEmpty(t, c.ProcessID)
+}
+
+func TestConfigOptions(t *testing.T) {
+	c := config.NewConfig(
+		config.WithApplicationName("TestName"),
+		config.WithEnvironmentName("TestEnv"),
+		config.WithDebug(true),
+		config.WithLogPath("/"),
+		config.WithLogFileThresholdSize(100),
+		config.WithTransportType("default"),
+	)
+
+	assert.Equal(t, c.ApplicationName, "TestName")
+	assert.Equal(t, c.EnvironmentName, "TestEnv")
+	assert.Equal(t, c.Debug, true)
+	assert.Equal(t, c.TransportType, "default")
+	assert.Equal(t, c.LogPath, "/")
+	assert.Equal(t, c.LogFileThresholdSize, int64(100))
+	assert.NotEmpty(t, c.BaseDIR)
+	assert.NotEmpty(t, c.HostName)
+	assert.NotEmpty(t, c.OSType)
+	assert.NotEmpty(t, c.ProcessID)
+}
+
+func TestConfigOptionInvalidTransportType(t *testing.T) {
+	c := config.NewConfig(
+		config.WithTransportType("invalid"),
+	)
+
+	assert.Equal(t, c.TransportType, "default")
+}

--- a/config/constants.go
+++ b/config/constants.go
@@ -5,3 +5,9 @@ const (
 	DefaultTransportType        string = "default"
 	MaxLogFilesCount            int    = 10
 )
+
+var (
+	TransportTypes = map[string]bool{
+		DefaultTransportType: true,
+	}
+)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,6 +5,7 @@
 1. Install Go 1.15
 
 2. Clone Repository
+
     http: `git clone https://<user>@bitbucket.org/stackify/stackify-go-apm.git`
     ssh:  `git clone git@bitbucket.org:stackify/stackify-go-apm.git`
 

--- a/trace/common_test.go
+++ b/trace/common_test.go
@@ -1,0 +1,57 @@
+package trace_test
+
+import (
+	"time"
+
+	"github.com/stackify/stackify-go-apm/config"
+	"github.com/stackify/stackify-go-apm/trace/span"
+	apitrace "go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/codes"
+	export "go.opentelemetry.io/otel/sdk/export/trace"
+)
+
+var (
+	invalidSpanId = apitrace.SpanID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	parentSpanID  = apitrace.SpanID{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8}
+	childSpanID   = apitrace.SpanID{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
+)
+
+func createConfig() *config.Config {
+	return config.NewConfig(
+		config.WithApplicationName("TestApp"),
+		config.WithEnvironmentName("test"),
+	)
+}
+
+func createOtelSpanData(c *config.Config, name string, kind apitrace.SpanKind, spanId apitrace.SpanID, parentId apitrace.SpanID) *export.SpanData {
+	c.ProcessID = "ProcessID"
+	c.HostName = "HostName"
+	c.OSType = "OSType"
+	c.BaseDIR = "BaseDIR"
+	startTime := time.Unix(1585674086, 1234)
+	endTime := startTime.Add(10 * time.Second)
+	return &export.SpanData{
+		SpanContext: apitrace.SpanContext{
+			TraceID: apitrace.ID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+			SpanID:  spanId,
+		},
+		SpanKind:     kind,
+		ParentSpanID: parentId,
+		Name:         name,
+		StartTime:    startTime,
+		EndTime:      endTime,
+		StatusCode:   codes.Error,
+	}
+}
+
+type testTransport struct {
+	HandleTraceCallCount int
+	SendAllCallCount     int
+}
+
+func (dt *testTransport) HandleTrace(stackifySpan *span.StackifySpan) {
+	dt.HandleTraceCallCount += 1
+}
+func (dt *testTransport) SendAll() {
+	dt.SendAllCallCount += 1
+}

--- a/trace/exporter_test.go
+++ b/trace/exporter_test.go
@@ -1,0 +1,53 @@
+package trace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	apitrace "go.opentelemetry.io/otel/api/trace"
+	export "go.opentelemetry.io/otel/sdk/export/trace"
+
+	"github.com/stackify/stackify-go-apm/trace"
+	"github.com/stackify/stackify-go-apm/transport"
+)
+
+func TestTransportExportSpans(t *testing.T) {
+	c := createConfig()
+	tt := &testTransport{}
+	tr := transport.Transport(tt)
+	exporter := trace.NewStackifySpanExporter(c, &tr)
+	sd := createOtelSpanData(c, "custom", apitrace.SpanKindClient, parentSpanID, invalidSpanId)
+
+	exporter.ExportSpans(context.Background(), []*export.SpanData{sd})
+
+	assert.Equal(t, tt.HandleTraceCallCount, 1)
+	assert.Equal(t, tt.SendAllCallCount, 0)
+}
+
+func TestTransportShutdown(t *testing.T) {
+	c := createConfig()
+	tt := &testTransport{}
+	tr := transport.Transport(tt)
+	exporter := trace.NewStackifySpanExporter(c, &tr)
+
+	exporter.Shutdown(context.Background())
+
+	assert.Equal(t, tt.HandleTraceCallCount, 0)
+	assert.Equal(t, tt.SendAllCallCount, 1)
+}
+
+func TestParentChildSpans(t *testing.T) {
+	c := createConfig()
+	tt := &testTransport{}
+	tr := transport.Transport(tt)
+	exporter := trace.NewStackifySpanExporter(c, &tr)
+	parent := createOtelSpanData(c, "custom", apitrace.SpanKindClient, parentSpanID, invalidSpanId)
+	child := createOtelSpanData(c, "custom", apitrace.SpanKindClient, childSpanID, parentSpanID)
+
+	exporter.ExportSpans(context.Background(), []*export.SpanData{parent, child})
+
+	assert.Equal(t, tt.HandleTraceCallCount, 1)
+	assert.Equal(t, tt.SendAllCallCount, 0)
+}

--- a/trace/span_processor.go
+++ b/trace/span_processor.go
@@ -47,7 +47,7 @@ var (
 )
 
 const (
-	DefaultTimeout = 500 * time.Millisecond
+	DefaultTimeout = 50 * time.Millisecond
 )
 
 type StackifySpanProcessor struct {
@@ -118,6 +118,7 @@ func (ssp *StackifySpanProcessor) Shutdown() {
 		ssp.enqueue(invalidTraceID)
 		ssp.stopWait.Wait()
 	})
+	ssp.e.Shutdown(context.Background())
 }
 
 // ForceFlush export remaining traces from queue.

--- a/trace/span_processor_test.go
+++ b/trace/span_processor_test.go
@@ -1,0 +1,66 @@
+package trace_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stackify/stackify-go-apm/trace"
+	"github.com/stackify/stackify-go-apm/transport"
+	apitrace "go.opentelemetry.io/otel/api/trace"
+)
+
+func TestSpanProcessorOnStartAndOnEnd(t *testing.T) {
+	c := createConfig()
+	tt := &testTransport{}
+	tr := transport.Transport(tt)
+	spe := trace.NewStackifySpanExporter(c, &tr)
+	ssp := trace.NewStackifySpanProcessor(spe)
+	sd := createOtelSpanData(c, "custom", apitrace.SpanKindClient, parentSpanID, invalidSpanId)
+
+	ssp.OnStart(sd)
+	ssp.OnEnd(sd)
+
+	// sleep making sure we processes span convertion
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, tt.HandleTraceCallCount, 1)
+}
+
+func TestSpanProcessorShutDown(t *testing.T) {
+	c := createConfig()
+	tt := &testTransport{}
+	tr := transport.Transport(tt)
+	spe := trace.NewStackifySpanExporter(c, &tr)
+	ssp := trace.NewStackifySpanProcessor(spe)
+	sd := createOtelSpanData(c, "custom", apitrace.SpanKindClient, parentSpanID, invalidSpanId)
+
+	ssp.OnStart(sd)
+	ssp.OnEnd(sd)
+	ssp.Shutdown()
+
+	// sleep making sure we processes span convertion
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, tt.HandleTraceCallCount, 1)
+	assert.Equal(t, tt.SendAllCallCount, 1)
+}
+
+func TestSpanProcessorForceFlush(t *testing.T) {
+	c := createConfig()
+	tt := &testTransport{}
+	tr := transport.Transport(tt)
+	spe := trace.NewStackifySpanExporter(c, &tr)
+	ssp := trace.NewStackifySpanProcessor(spe)
+	sd := createOtelSpanData(c, "custom", apitrace.SpanKindClient, parentSpanID, invalidSpanId)
+
+	ssp.OnStart(sd)
+	ssp.OnEnd(sd)
+	ssp.ForceFlush()
+
+	// sleep making sure we processes span convertion
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, tt.HandleTraceCallCount, 1)
+}


### PR DESCRIPTION
Changes:
- add common test cases variables into common file
- add test cases for exporter
- add test cases for span processor
- add test cases for config
- update readme

Test results:
```
Running Tests and exclude example and instrumentation directories.
?       github.com/stackify/stackify-go-apm     [no test files]
ok      github.com/stackify/stackify-go-apm/config      0.002s  coverage: 100.0% of statements
ok      github.com/stackify/stackify-go-apm/trace       0.306s  coverage: 88.0% of statements
ok      github.com/stackify/stackify-go-apm/trace/span  0.003s  coverage: 100.0% of statements
ok      github.com/stackify/stackify-go-apm/transport   0.010s  coverage: 92.9% of statements
ok      github.com/stackify/stackify-go-apm/utils       0.009s  coverage: 100.0% of statements
Done running tests.

```