### PR TITLE
GoProfiler - Fix issue with Manual Instrumentation

### DIFF
--- a/apm.go
+++ b/apm.go
@@ -45,7 +45,7 @@ func NewStackifyAPM(opts ...config.ConfigOptions) (*StackifyAPM, error) {
 
 	// set tracer provider as global tracer provider
 	global.SetTracerProvider(tp)
-	tracer := global.Tracer("stackifyapm_tracer")
+	tracer := global.Tracer(config.StackifyInstrumentationName)
 
 	// create context
 	ctx := context.Background()

--- a/apm.go
+++ b/apm.go
@@ -2,7 +2,6 @@ package apm
 
 import (
 	"context"
-	"time"
 
 	"github.com/stackify/stackify-go-apm/config"
 	"github.com/stackify/stackify-go-apm/trace"
@@ -23,7 +22,6 @@ type StackifyAPM struct {
 }
 
 func (sapm *StackifyAPM) Shutdown() {
-	time.Sleep(1 * time.Second)
 	sapm.spanProcessor.Shutdown()
 }
 

--- a/apm_test.go
+++ b/apm_test.go
@@ -1,0 +1,26 @@
+package apm_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	apm "github.com/stackify/stackify-go-apm"
+)
+
+func TestStackifyAPM(t *testing.T) {
+	stackifyapm, err := apm.NewStackifyAPM()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, stackifyapm.Context)
+	assert.NotNil(t, stackifyapm.Tracer)
+	assert.NotNil(t, stackifyapm.TraceProvider)
+}
+
+func TestStackifyAPMShutDown(t *testing.T) {
+	stackifyapm, err := apm.NewStackifyAPM()
+
+	stackifyapm.Shutdown()
+
+	assert.Nil(t, err)
+}

--- a/config/constants.go
+++ b/config/constants.go
@@ -1,6 +1,7 @@
 package config
 
 const (
+	StackifyInstrumentationName string = "stackifyapm_tracer"
 	DefaultLogFileThresholdSize int64  = 50000000
 	DefaultTransportType        string = "default"
 	MaxLogFilesCount            int    = 10

--- a/trace/span_processor.go
+++ b/trace/span_processor.go
@@ -10,12 +10,14 @@ import (
 	"go.opentelemetry.io/otel/api/trace"
 	export "go.opentelemetry.io/otel/sdk/export/trace"
 
+	"github.com/stackify/stackify-go-apm/config"
 	"github.com/stackify/stackify-go-apm/trace/span"
 )
 
 var (
 	invalidTraceID trace.ID
-	validSpan      = map[string]bool{
+	// TODO: find a better way of doing this
+	validSpan = map[string]bool{
 		// HTML
 		"GET":    true,
 		"POST":   true,
@@ -214,7 +216,9 @@ func (ssp *StackifySpanProcessor) isTraceExportable(trace_id trace.ID) bool {
 func (ssp *StackifySpanProcessor) isSpanValid(sd *export.SpanData) bool {
 	_, ok := validSpan[sd.Name]
 	if !ok {
-		ok = sd.InstrumentationLibrary.Name == span.Otelgocql || sd.InstrumentationLibrary.Name == span.Otelgrpc
+		ok = sd.InstrumentationLibrary.Name == span.Otelgocql ||
+			sd.InstrumentationLibrary.Name == span.Otelgrpc ||
+			sd.InstrumentationLibrary.Name == config.StackifyInstrumentationName
 	}
 	return ok || sd.ParentSpanID == span.InvalidSpanId
 }


### PR DESCRIPTION
Changes:
- fix issue with manual instrumentation not showing child spans
- set constant for stackify instrumentation name

test case result:
```
Running Tests and exclude example and instrumentation directories.
ok      github.com/stackify/stackify-go-apm     0.002s  coverage: 100.0% of statements
ok      github.com/stackify/stackify-go-apm/config      0.003s  coverage: 100.0% of statements
ok      github.com/stackify/stackify-go-apm/trace       0.305s  coverage: 88.0% of statements
ok      github.com/stackify/stackify-go-apm/trace/span  0.003s  coverage: 100.0% of statements
ok      github.com/stackify/stackify-go-apm/transport   0.011s  coverage: 91.1% of statements
ok      github.com/stackify/stackify-go-apm/utils       0.013s  coverage: 100.0% of statements
Done running tests.

```